### PR TITLE
Add example server and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # KellerC2
+
+This repository contains a simple example of a command and control setup with a
+Python web server and a minimal C++ client. The server keeps track of clients
+that register with it and exposes an endpoint to view the list of currently
+connected clients.
+
+## Server
+
+The server is implemented in `server.py` and uses Python's built-in HTTP
+modules, so no additional dependencies are required.
+
+### Running the server
+
+```bash
+python3 server.py
+```
+
+By default the server listens on port `8000`.
+
+### Endpoints
+
+- `POST /register` – Clients post a JSON payload `{"client_id": "<id>"}` to
+  register themselves.
+- `GET /clients` – Returns a JSON array containing the IDs of all registered
+  clients.
+
+## Client
+
+`client.cpp` demonstrates a small program that connects to the server and
+registers itself.
+
+### Building the client
+
+```bash
+g++ -std=c++11 client.cpp -o client
+```
+
+### Running the client
+
+```bash
+./client my_client_id
+```
+
+After running one or more clients, requesting `http://localhost:8000/clients`
+will show the list of registered clients.

--- a/client.cpp
+++ b/client.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <string>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+    std::string host = "localhost";
+    std::string port = "8000";
+    std::string client_id = "client_" + std::to_string(getpid());
+    if (argc > 1) client_id = argv[1];
+
+    addrinfo hints{};
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    addrinfo* res;
+    if (getaddrinfo(host.c_str(), port.c_str(), &hints, &res) != 0) {
+        perror("getaddrinfo");
+        return 1;
+    }
+
+    int sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+    if (sock < 0) {
+        perror("socket");
+        freeaddrinfo(res);
+        return 1;
+    }
+
+    if (connect(sock, res->ai_addr, res->ai_addrlen) < 0) {
+        perror("connect");
+        close(sock);
+        freeaddrinfo(res);
+        return 1;
+    }
+
+    std::string body = "{\"client_id\":\"" + client_id + "\"}";
+    std::string request;
+    request += "POST /register HTTP/1.1\r\n";
+    request += "Host: " + host + "\r\n";
+    request += "Content-Type: application/json\r\n";
+    request += "Content-Length: " + std::to_string(body.size()) + "\r\n";
+    request += "\r\n";
+    request += body;
+
+    if (send(sock, request.c_str(), request.size(), 0) < 0) {
+        perror("send");
+    }
+
+    char buf[1024];
+    ssize_t n = recv(sock, buf, sizeof(buf) - 1, 0);
+    if (n > 0) {
+        buf[n] = '\0';
+        std::cout << buf << std::endl;
+    }
+
+    close(sock);
+    freeaddrinfo(res);
+    return 0;
+}

--- a/server.py
+++ b/server.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+
+clients = set()
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if self.path == '/register':
+            length = int(self.headers.get('Content-Length', 0))
+            data = self.rfile.read(length)
+            client_id = None
+            try:
+                payload = json.loads(data.decode())
+                client_id = payload.get('client_id')
+            except Exception:
+                pass
+            if client_id:
+                clients.add(client_id)
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'Registered')
+            else:
+                self.send_response(400)
+                self.end_headers()
+                self.wfile.write(b'Bad Request')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_GET(self):
+        if self.path == '/clients':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(sorted(list(clients))).encode())
+        else:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'Server is running')
+
+def run(port=8000):
+    server_address = ('', port)
+    httpd = HTTPServer(server_address, Handler)
+    print(f'Starting server on port {port}...')
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add python web server storing registered clients
- add C++ client that registers itself with the server
- document how to build and run the components

## Testing
- `g++ -std=c++11 client.cpp -o client`
- `python3 server.py` (background)
- `./client test_client`
- `curl http://localhost:8000/clients`

------
https://chatgpt.com/codex/tasks/task_e_6848454f3a6c833083c2984f08a4fa3b