### PR TITLE
Add SQLite persistence and cleanup task

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ python server.py
 
 By default the server listens on port `8000`.
 
+All client registrations, queued commands and results are stored in an
+`SQLite` database named `keller.db`. Each time a client polls the `/poll`
+endpoint its `last_seen` timestamp is updated. A background task runs every
+minute to remove clients that have not been seen for an hour. The interval can
+be changed by setting the `REMOVE_CLIENT_AFTER` environment variable.
+
 ### Endpoints
 
 - `POST /register` – Clients post a JSON payload


### PR DESCRIPTION
## Summary
- persist client data and queued commands in `keller.db`
- track `last_seen` on poll
- periodically remove stale clients with a background thread
- document new behaviour and configuration in README

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_e_68496c10d818833095a7c0c863261299