### PR TITLE
Store result history

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ be changed by setting the `REMOVE_CLIENT_AFTER` environment variable.
   `{"client_id": "<id>", "command": "<cmd>"}`.
 - `GET /result?client_id=<id>` – Retrieves the latest stored result for a
   client.
+- `GET /history?client_id=<id>` – Returns up to 10 recent results for a client
+  as `[{"result": "<output>", "ts": <epoch_seconds>}, ...]`.
+- `GET /commands?client_id=<id>` – Returns up to 10 recent commands queued for a client as `[{"command": "<cmd>", "ts": <epoch_seconds>}, ...]`.
 
 ## Client
 


### PR DESCRIPTION
## Summary
- keep history of client results in a new `results` table
- display multiple results in UI when a marker is opened
- expose new `/history` endpoint and document it
- keep a history of queued commands with `/commands`
- show command history in popup

## Testing
- `python -m py_compile server.py`
- manual server check: `/commands` and `/history` endpoints work

------
https://chatgpt.com/codex/tasks/task_e_684977e762688330adae984bcfbc406b